### PR TITLE
redis 서버 분리에 따른 RedisConfig 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
 version: "3"
 services:
-  redis-service:
-    image: redis:7-alpine
-
   springboot-service:
     image: 205930641663.dkr.ecr.ap-northeast-2.amazonaws.com/bodycheck/springboot:latest
     environment:
@@ -24,13 +21,12 @@ services:
       - PROFILE_ACTIVE=${PROFILE_ACTIVE}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
+      - REDIS_SSL_ENABLED=${REDIS_SSL_ENABLED}
       - MAIL_EMAIL=${MAIL_EMAIL}
       - MAIL_PASSWORD=${MAIL_PASSWORD}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "8080:8080"
-    depends_on:
-      - redis-service
 
   nginx-service:
     image: 205930641663.dkr.ecr.ap-northeast-2.amazonaws.com/bodycheck/nginx:latest

--- a/src/main/java/org/example/bodycheck/common/config/RedisConfig.java
+++ b/src/main/java/org/example/bodycheck/common/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -20,13 +21,23 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.ssl.enabled}")
+    private Boolean ssl;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(port);
 
-        return new LettuceConnectionFactory(host, port);
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigurationBuilder =
+                LettuceClientConfiguration.builder();
+
+        if (Boolean.TRUE.equals(ssl)) {
+            clientConfigurationBuilder.useSsl();
+        }
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfigurationBuilder.build());
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,8 @@ spring:
     redis:
       host: ${redis.host}
       port: ${redis.port}
+      ssl:
+        enabled: ${redis.ssl.enabled}
 
   servlet:
     multipart:
@@ -120,6 +122,8 @@ spring:
     redis:
       host: ${redis.host}
       port: ${redis.port}
+      ssl:
+        enabled: ${redis.ssl.enabled}
 
   servlet:
     multipart:


### PR DESCRIPTION
**변경 내용**
- Redis 설정을 애플리케이션 인스턴스 내 실행 방식에서 외부 Redis 서버 분리 방식으로 수정

**변경 이유**
- 기존 구조에서는 Redis가 애플리케이션 인스턴스 내에 포함되어 있어, 무중단 배포(rolling update) 시 인스턴스가 교체되면 Redis에 저장된 데이터가 유실되는 문제가 발생함
- Redis를 독립 서버로 분리하여 운영함으로써 배포 시에도 데이터가 유지되어 안정적인 캐시 관리가 가능하도록 개선