### PR TITLE
[CORE] .bat 파일을 제외한 모든 파일의 설정을 LF로 적용

### DIFF
--- a/naver-checkstyle-rules.xml
+++ b/naver-checkstyle-rules.xml
@@ -25,15 +25,15 @@ The following rules in the Naver coding convention cannot be checked by this con
 	<property name="charset" value="UTF-8"/>
 
 	<!-- [newline-lf] -->
-<!--	<module name="RegexpMultiline">-->
-<!--		<property name="format" value="\r\n"/>-->
-<!--		<property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>-->
-<!--	</module>-->
+	<module name="RegexpMultiline">
+		<property name="format" value="\r\n"/>
+		<property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>
+	</module>
 
 	<!-- [newline-eof] -->
-<!--    <module name="NewlineAtEndOfFile">-->
-<!--        <property name="lineSeparator" value="lf"/>-->
-<!--    </module>-->
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
 
     <!-- [no-trailing-spaces] -->
 	<module name="RegexpSingleline">


### PR DESCRIPTION
## Issue number
#178 
## Summary & Screenshots
- .bat 파일을 제외한 모든 파일의 설정을 LF로 적용하고, 인텔리제이 설정으로 LF로 파일을 생성하도록 설정
## Describe your changes (option)

## Things to consider (option)
