### PR TITLE
[CORE] .bat 파일 LF로 적용하고, editorconfig에서 .bat파일 설정 주석 처리

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,8 @@ end_of_line = lf
 # [newline-eof]
 insert_final_newline = true
 
-[*.bat]
-end_of_line = crlf
+# [*.bat]
+# end_of_line = crlf
 
 [*.java]
 # [indentation-tab]


### PR DESCRIPTION
## Issue number
 #178 
## Summary & Screenshots
- .bat 파일을 LF로 적용하고, editorconfig에서 .bat파일 설정 주석 처리하였습니다. 
## Describe your changes (option)

## Things to consider (option)
